### PR TITLE
Fixed URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ If neither of these flags are set, logging will only be shown if an error occurs
 $ python3 gatorgrouper.py --group-size 3 --absentees becky george --random
 
 GatorGrouper: Automatically Assign Students to Groups
-https://github.com/gkapfham/gatorgrouper
+https://github.com/GatorEducator/gatorgrouper
 
 Successfully placed 9 students into 3 groups
 


### PR DESCRIPTION
Edited the URL in the example code output to have the correct URL

I'm merging this branch to master so that the README.md displays the correct URL in the example output code block.

This is an easy fix.

Fixes #98 :

## Type of Change

- [x] Bug fix
- [ ] Breaking change
- [ ] New feature
- [x] Documentation update
- [ ] Other (Please specify any helpful information below)

## Tags

@gkapfham @Michionlion @Alex-Yarkosky @sutterj @toccinAC 

