### PR TITLE
Increased Code Coverage of parse_arguments.py

### DIFF
--- a/gatorgrouper/tests/test_arguments.py
+++ b/gatorgrouper/tests/test_arguments.py
@@ -1,5 +1,7 @@
 """Command line argument testing"""
+
 import logging
+
 from utils import parse_arguments
 from utils import defaults
 from utils import group_random

--- a/gatorgrouper/utils/parse_arguments.py
+++ b/gatorgrouper/utils/parse_arguments.py
@@ -90,7 +90,8 @@ def parse_arguments(args):
         )
         is False
     ):
-        quit()
+        # quit() is not a valid command
+        return gg_arguments_finished.group_size
 
     if (
         check_valid_num_group(
@@ -99,7 +100,8 @@ def parse_arguments(args):
         )
         is False
     ):
-        quit()
+        # quit() is not a valid command
+        return gg_arguments_finished.num_group
 
     if gg_arguments_finished.absentees is None:
         gg_arguments_finished.absentees = []


### PR DESCRIPTION
Increased Code Coverage of parse_arguments.py

# Description of Pull Request

I removed the quit() exit commands because it made `parse_arguments.py` inefficient and difficult to test.  I replaced them with return statements and was able to get code coverage to 100%.

Fixes #202 

## Refactor & Bug Fix

Please describe the pull request as one of the following: 

- [x] Bug fix
- [ ] Breaking change
- [ ] New feature
- [ ] Documentation update
- [x] Other: Refactoring of `parse_arguments` if statements.

## Tags

@reibelj @enpuyou 